### PR TITLE
Update casing of pt_BR messages

### DIFF
--- a/timeago/lib/src/messages/pt_br_messages.dart
+++ b/timeago/lib/src/messages/pt_br_messages.dart
@@ -3,7 +3,7 @@ import 'package:timeago/src/messages/lookupmessages.dart';
 /// Portuguese-Brazil messages
 class PtBrMessages implements LookupMessages {
   @override
-  String prefixAgo() => 'Há';
+  String prefixAgo() => 'há';
   @override
   String prefixFromNow() => 'em';
   @override


### PR DESCRIPTION
The `prefixAgo` string was incorrectly cased. The project default seems to be all lower cases.

Fixes #150.